### PR TITLE
include token addresses en autocompound events

### DIFF
--- a/contracts/Contract.sol
+++ b/contracts/Contract.sol
@@ -259,7 +259,7 @@ contract Contract is IContract, ReentrancyGuard, Ownable, Multicall {
             _withdrawFullBalances(state.token0, state.token1, msg.sender);
         }
 
-        emit AutoCompounded(msg.sender, params.tokenId, compounded0, compounded1, bonus0, bonus1);
+        emit AutoCompounded(msg.sender, params.tokenId, compounded0, compounded1, bonus0, bonus1, state.token0, state.token1);
     }
 
     struct SwapAndMintState {

--- a/contracts/IContract.sol
+++ b/contracts/IContract.sol
@@ -29,7 +29,9 @@ interface IContract is IERC721Receiver {
         uint256 amountAdded0,
         uint256 amountAdded1,
         uint256 bonus0,
-        uint256 bonus1
+        uint256 bonus1,
+        address token0,
+        address token1
     );
 
     /// @notice The weth address


### PR DESCRIPTION
Increases autocompounding gas costs in the tests for about 500 wei in the worst case.